### PR TITLE
filtered by content type

### DIFF
--- a/Controller/Component/SwitcherComponent.php
+++ b/Controller/Component/SwitcherComponent.php
@@ -29,6 +29,12 @@ class SwitcherComponent extends Component {
 	public function getThemeLayouts() {
 		$themes = $this->Croogo->getThemes();
 		$available = array();
+
+		/* Get only active Theme & filter it by Content Type */
+		if (Configure::read('Switcher.ActiveByContentType')) {
+			$themes = [Configure::read('Site.theme')];
+		}
+
 		foreach ($themes as $theme) {
 			if ($theme == 'default') { continue; }
 			$path = App::themePath($theme);

--- a/View/Helper/SwitcherHelper.php
+++ b/View/Helper/SwitcherHelper.php
@@ -4,6 +4,7 @@ class SwitcherHelper extends AppHelper {
 
 	public $helpers = array(
 		'Form',
+		'Theme',
 	);
 
 /**
@@ -16,6 +17,7 @@ class SwitcherHelper extends AppHelper {
 			return array();
 		}
 		$options = array();
+		$themedLayouts = $this->activeByContentType($themedLayouts);
 		foreach ($themedLayouts as $theme => $data) {
 			$layouts = array();
 			$themeLayouts = array_keys($data['layouts']);
@@ -25,6 +27,38 @@ class SwitcherHelper extends AppHelper {
 			$options[$theme] = $layouts;
 		}
 		return $options;
+	}
+
+	public function getActiveTheme() {
+		return Configure::read('Site.theme');
+	}
+
+	public function activeByContentType($layouts = array()) {
+		if (Configure::read('Switcher.ActiveByContentType')) {
+			$theme = $this->getActiveTheme();
+			$config = CroogoTheme::config($theme);
+			if (empty($config['switcher']['content-type'])) {
+				return $layoutss;
+			}
+
+			$activeTypes = $config['switcher']['content-type'];
+			$type = $this->_View->viewVars['typeAlias'];
+
+			if (!isset($activeTypes[$type])) {
+				return $layouts;
+			}
+			$values = $activeTypes[$type];
+			$filtered = array_filter($layouts[$theme]['layouts'], function ($k) use ($values) {
+				if (!in_array($k, $values)) {
+					unset($k);
+				} else {
+					return $k;
+				}
+			}, ARRAY_FILTER_USE_KEY);
+			$layouts[$theme]['layouts'] = $filtered;
+			return $layouts;
+		}
+		return array();
 	}
 
 /**


### PR DESCRIPTION
how to use:
- create settings key Switcher.ActiveByContentType = 1 on croogo
- add this configuration on theme.json.

`
"switcher": {
        "content-type": {
        "promotion": ["left-sidebar", "right-sidebar"],
        "page": ["all", "default"]
    }
}
`

note: moving this configuration onto configure::read instead.
